### PR TITLE
[TASK] Stop linking the extension to the dependent TYPO3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,17 +43,6 @@
 		],
 		"ci": [
 			"@ci:static"
-		],
-		"require-typo3-version": [
-			"@php -r '$conf=json_decode(file_get_contents(__DIR__.\"/composer.json\"),true);$conf[\"require\"][\"typo3/cms-core\"]=$_SERVER[\"argv\"][1];file_put_contents(__DIR__.\"/composer.json\",json_encode($conf,JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT).chr(10));'",
-			"@composer install"
-		],
-		"link-extension": [
-			"@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
-			"@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/typo3_devsite\") || symlink(__DIR__,$extFolder);'"
-		],
-		"post-autoload-dump": [
-			"@link-extension"
 		]
 	},
 	"extra": {


### PR DESCRIPTION
As this extension has no unit or functional tests, there is no
need to have a testing TYPO3 setup within it.