### PR TITLE
[BUGFIX] Use `$_EXTKEY` in `ext_emconf.php` again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop support for PHP 7.0 and 7.1 (#91)
 
 ### Fixed
-- Stop using `$_EXTKEY` (#97)
 
 ## 3.1.0
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,5 @@
 <?php
-$EM_CONF['typo3_devsite'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'TYPO3 CMS development site',
     'description' => 'Contains the basics of a site which Oliver Klee uses for developing in TYPO3.',
     'category' => 'services',


### PR DESCRIPTION
According to the docs, the TER needs this.

This reverts commit d42097098e5a9dfd77b97c3cfb450e1400846107.